### PR TITLE
Add restaurant orders plugin with tests and logging

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+DB_NAME=${1-wp_tests}
+DB_USER=${2-root}
+DB_PASS=${3-''}
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+install_wp() {
+  if [ -d $WP_CORE_DIR ]; then
+    return
+  fi
+  mkdir -p $WP_CORE_DIR
+  wget -nv -O /tmp/wordpress.tar.gz https://wordpress.org/wordpress-${WP_VERSION}.tar.gz
+  tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+}
+
+install_test_suite() {
+  if [ -d $WP_TESTS_DIR ]; then
+    return
+  fi
+  mkdir -p $WP_TESTS_DIR
+  wget -nv -O /tmp/wordpress-tests-lib.tar.gz https://develop.svn.wordpress.org/tags/${WP_VERSION}/tests/phpunit/includes/export.tar.gz
+  tar --strip-components=1 -zxmf /tmp/wordpress-tests-lib.tar.gz -C $WP_TESTS_DIR
+}
+
+install_db() {
+  mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS" --host="$DB_HOST" --force
+}
+
+install_wp
+install_test_suite
+install_db

--- a/includes/class-restaurant-orders-logger.php
+++ b/includes/class-restaurant-orders-logger.php
@@ -1,0 +1,24 @@
+<?php
+class Restaurant_Orders_Logger {
+    const OPTION_KEY = 'restaurant_orders_debug_logging';
+
+    public function is_enabled() {
+        return (bool) get_option( self::OPTION_KEY, false );
+    }
+
+    public function log( $message ) {
+        if ( ! $this->is_enabled() ) {
+            return;
+        }
+
+        $upload_dir = wp_upload_dir();
+        $log_path   = trailingslashit( $upload_dir['basedir'] ) . 'restaurant-orders-debug.log';
+
+        if ( ! file_exists( $upload_dir['basedir'] ) ) {
+            wp_mkdir_p( $upload_dir['basedir'] );
+        }
+
+        $line = sprintf( "[%s] %s\n", current_time( 'mysql' ), $message );
+        file_put_contents( $log_path, $line, FILE_APPEND );
+    }
+}

--- a/includes/class-restaurant-orders-rest.php
+++ b/includes/class-restaurant-orders-rest.php
@@ -1,0 +1,359 @@
+<?php
+class Restaurant_Orders_REST {
+    private $plugin;
+    private $logger;
+    private $namespace = 'restaurant/v1';
+
+    public function __construct( Restaurant_Orders $plugin, Restaurant_Orders_Logger $logger ) {
+        $this->plugin = $plugin;
+        $this->logger = $logger;
+    }
+
+    public function register_routes() {
+        register_rest_route(
+            $this->namespace,
+            '/items',
+            [
+                [
+                    'methods'             => WP_REST_Server::CREATABLE,
+                    'callback'            => [ $this, 'create_item' ],
+                    'permission_callback' => [ $this, 'can_manage' ],
+                    'args'                => $this->get_item_schema(),
+                ],
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [ $this, 'list_items' ],
+                    'permission_callback' => [ $this, 'can_read' ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/items/(?P<id>\d+)',
+            [
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [ $this, 'get_item' ],
+                    'permission_callback' => [ $this, 'can_read' ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::EDITABLE,
+                    'callback'            => [ $this, 'update_item' ],
+                    'permission_callback' => [ $this, 'can_manage' ],
+                    'args'                => $this->get_item_schema(),
+                ],
+                [
+                    'methods'             => WP_REST_Server::DELETABLE,
+                    'callback'            => [ $this, 'delete_item' ],
+                    'permission_callback' => [ $this, 'can_manage' ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/orders',
+            [
+                [
+                    'methods'             => WP_REST_Server::CREATABLE,
+                    'callback'            => [ $this, 'create_order' ],
+                    'permission_callback' => [ $this, 'can_manage' ],
+                    'args'                => $this->get_order_schema(),
+                ],
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [ $this, 'list_orders' ],
+                    'permission_callback' => [ $this, 'can_read' ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/orders/(?P<id>\d+)',
+            [
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [ $this, 'get_order' ],
+                    'permission_callback' => [ $this, 'can_read' ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::EDITABLE,
+                    'callback'            => [ $this, 'update_order' ],
+                    'permission_callback' => [ $this, 'can_manage' ],
+                    'args'                => [
+                        'status' => [
+                            'required' => false,
+                            'type'     => 'string',
+                        ],
+                        'restaurant_id' => [
+                            'required' => false,
+                            'type'     => 'integer',
+                        ],
+                        'items' => [
+                            'required' => false,
+                            'type'     => 'array',
+                        ],
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::DELETABLE,
+                    'callback'            => [ $this, 'delete_order' ],
+                    'permission_callback' => [ $this, 'can_manage' ],
+                ],
+            ]
+        );
+
+        register_rest_route(
+            $this->namespace,
+            '/orders/(?P<id>\d+)/notify',
+            [
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => [ $this, 'notify_order' ],
+                'permission_callback' => [ $this, 'can_manage' ],
+                'args'                => [
+                    'result' => [
+                        'required' => true,
+                        'type'     => 'string',
+                        'enum'     => [ 'success', 'failure' ],
+                    ],
+                ],
+            ]
+        );
+    }
+
+    public function can_manage() {
+        return current_user_can( 'manage_options' );
+    }
+
+    public function can_read() {
+        return current_user_can( 'read' );
+    }
+
+    public function create_item( WP_REST_Request $request ) {
+        $post_id = wp_insert_post(
+            [
+                'post_type'   => Restaurant_Orders::ITEM_CPT,
+                'post_title'  => sanitize_text_field( $request['name'] ),
+                'post_status' => 'publish',
+                'meta_input'  => [
+                    'price'         => floatval( $request['price'] ),
+                    'restaurant_id' => intval( $request['restaurant_id'] ),
+                ],
+            ]
+        );
+
+        return $this->prepare_item_for_response( get_post( $post_id ), $request );
+    }
+
+    public function get_item( WP_REST_Request $request ) {
+        $post = get_post( (int) $request['id'] );
+        return $this->prepare_item_for_response( $post, $request );
+    }
+
+    public function update_item( WP_REST_Request $request ) {
+        $post_id = (int) $request['id'];
+
+        wp_update_post(
+            [
+                'ID'         => $post_id,
+                'post_title' => sanitize_text_field( $request['name'] ),
+            ]
+        );
+
+        if ( null !== $request['price'] ) {
+            update_post_meta( $post_id, 'price', floatval( $request['price'] ) );
+        }
+
+        if ( null !== $request['restaurant_id'] ) {
+            update_post_meta( $post_id, 'restaurant_id', intval( $request['restaurant_id'] ) );
+        }
+
+        return $this->prepare_item_for_response( get_post( $post_id ), $request );
+    }
+
+    public function delete_item( WP_REST_Request $request ) {
+        $post = get_post( (int) $request['id'] );
+        wp_trash_post( $post->ID );
+        return rest_ensure_response( [ 'deleted' => true ] );
+    }
+
+    public function list_items( WP_REST_Request $request ) {
+        $args = [
+            'post_type'      => Restaurant_Orders::ITEM_CPT,
+            'posts_per_page' => -1,
+            'meta_query'     => [],
+        ];
+
+        if ( $request['restaurant_id'] ) {
+            $args['meta_query'][] = [
+                'key'   => 'restaurant_id',
+                'value' => intval( $request['restaurant_id'] ),
+            ];
+        }
+
+        $items = get_posts( $args );
+        return array_map( function ( $post ) use ( $request ) {
+            return $this->prepare_item_for_response( $post, $request );
+        }, $items );
+    }
+
+    public function create_order( WP_REST_Request $request ) {
+        $post_id = wp_insert_post(
+            [
+                'post_type'   => Restaurant_Orders::ORDER_CPT,
+                'post_title'  => sanitize_text_field( $request['name'] ?? 'Order' ),
+                'post_status' => sanitize_key( $request['status'] ?? 'pending' ),
+                'meta_input'  => [
+                    'items'         => wp_json_encode( $request['items'] ?? [] ),
+                    'restaurant_id' => intval( $request['restaurant_id'] ),
+                ],
+            ]
+        );
+
+        $this->logger->log( sprintf( 'Order %d created for restaurant %d', $post_id, intval( $request['restaurant_id'] ) ) );
+
+        return $this->prepare_order_for_response( get_post( $post_id ), $request );
+    }
+
+    public function get_order( WP_REST_Request $request ) {
+        $post = get_post( (int) $request['id'] );
+        return $this->prepare_order_for_response( $post, $request );
+    }
+
+    public function update_order( WP_REST_Request $request ) {
+        $post_id = (int) $request['id'];
+        $post    = get_post( $post_id );
+
+        $updated_post = [ 'ID' => $post_id ];
+
+        if ( null !== $request['status'] ) {
+            $updated_post['post_status'] = sanitize_key( $request['status'] );
+        }
+
+        if ( isset( $request['name'] ) ) {
+            $updated_post['post_title'] = sanitize_text_field( $request['name'] );
+        }
+
+        if ( count( $updated_post ) > 1 ) {
+            wp_update_post( $updated_post );
+        }
+
+        if ( null !== $request['restaurant_id'] ) {
+            update_post_meta( $post_id, 'restaurant_id', intval( $request['restaurant_id'] ) );
+        }
+
+        if ( null !== $request['items'] ) {
+            update_post_meta( $post_id, 'items', wp_json_encode( $request['items'] ) );
+        }
+
+        return $this->prepare_order_for_response( get_post( $post_id ), $request );
+    }
+
+    public function delete_order( WP_REST_Request $request ) {
+        wp_trash_post( (int) $request['id'] );
+        return rest_ensure_response( [ 'deleted' => true ] );
+    }
+
+    public function list_orders( WP_REST_Request $request ) {
+        $args = [
+            'post_type'      => Restaurant_Orders::ORDER_CPT,
+            'posts_per_page' => -1,
+            'meta_query'     => [],
+        ];
+
+        if ( $request['restaurant_id'] ) {
+            $args['meta_query'][] = [
+                'key'   => 'restaurant_id',
+                'value' => intval( $request['restaurant_id'] ),
+            ];
+        }
+
+        $orders = get_posts( $args );
+        return array_map( function ( $post ) use ( $request ) {
+            return $this->prepare_order_for_response( $post, $request );
+        }, $orders );
+    }
+
+    public function notify_order( WP_REST_Request $request ) {
+        $order_id = (int) $request['id'];
+        $result   = $request['result'];
+
+        $message = 'success' === $result
+            ? sprintf( 'Notification sent for order %d', $order_id )
+            : sprintf( 'Notification failed for order %d', $order_id );
+
+        $this->logger->log( $message );
+        return rest_ensure_response( [ 'notified' => $result ] );
+    }
+
+    private function prepare_item_for_response( $post, WP_REST_Request $request ) {
+        if ( ! $post ) {
+            return new WP_Error( 'not_found', __( 'Item not found', 'restaurant-orders' ), [ 'status' => 404 ] );
+        }
+
+        return rest_ensure_response(
+            [
+                'id'            => $post->ID,
+                'name'          => $post->post_title,
+                'price'         => (float) get_post_meta( $post->ID, 'price', true ),
+                'restaurant_id' => (int) get_post_meta( $post->ID, 'restaurant_id', true ),
+            ]
+        );
+    }
+
+    private function prepare_order_for_response( $post, WP_REST_Request $request ) {
+        if ( ! $post ) {
+            return new WP_Error( 'not_found', __( 'Order not found', 'restaurant-orders' ), [ 'status' => 404 ] );
+        }
+
+        return rest_ensure_response(
+            [
+                'id'            => $post->ID,
+                'name'          => $post->post_title,
+                'status'        => $post->post_status,
+                'restaurant_id' => (int) get_post_meta( $post->ID, 'restaurant_id', true ),
+                'items'         => json_decode( (string) get_post_meta( $post->ID, 'items', true ), true ),
+            ]
+        );
+    }
+
+    private function get_item_schema() {
+        return [
+            'name' => [
+                'required' => true,
+                'type'     => 'string',
+            ],
+            'price' => [
+                'required' => true,
+                'type'     => 'number',
+            ],
+            'restaurant_id' => [
+                'required' => true,
+                'type'     => 'integer',
+            ],
+        ];
+    }
+
+    private function get_order_schema() {
+        return [
+            'name' => [
+                'required' => false,
+                'type'     => 'string',
+            ],
+            'status' => [
+                'required' => false,
+                'type'     => 'string',
+            ],
+            'items' => [
+                'required' => false,
+                'type'     => 'array',
+            ],
+            'restaurant_id' => [
+                'required' => true,
+                'type'     => 'integer',
+            ],
+        ];
+    }
+}

--- a/includes/class-restaurant-orders-settings.php
+++ b/includes/class-restaurant-orders-settings.php
@@ -1,0 +1,64 @@
+<?php
+class Restaurant_Orders_Settings {
+    const OPTION_GROUP = 'restaurant_orders_options';
+    const OPTION_NAME  = Restaurant_Orders_Logger::OPTION_KEY;
+
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'register_settings_page' ] );
+        add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
+    }
+
+    public static function register_settings_page() {
+        add_options_page(
+            __( 'Restaurant Orders', 'restaurant-orders' ),
+            __( 'Restaurant Orders', 'restaurant-orders' ),
+            'manage_options',
+            'restaurant-orders',
+            [ __CLASS__, 'render_settings_page' ]
+        );
+    }
+
+    public static function register_settings() {
+        register_setting( self::OPTION_GROUP, self::OPTION_NAME, [ 'type' => 'boolean' ] );
+
+        add_settings_section(
+            'restaurant_orders_logging',
+            __( 'Debug Logging', 'restaurant-orders' ),
+            '__return_false',
+            'restaurant-orders'
+        );
+
+        add_settings_field(
+            'restaurant_orders_logging_enabled',
+            __( 'Enable debug log', 'restaurant-orders' ),
+            [ __CLASS__, 'render_logging_toggle' ],
+            'restaurant-orders',
+            'restaurant_orders_logging'
+        );
+    }
+
+    public static function render_logging_toggle() {
+        $value = (bool) get_option( self::OPTION_NAME, false );
+        ?>
+        <label for="restaurant-orders-debug-log">
+            <input type="checkbox" id="restaurant-orders-debug-log" name="<?php echo esc_attr( self::OPTION_NAME ); ?>" value="1" <?php checked( $value ); ?> />
+            <?php esc_html_e( 'Write order events to the debug log', 'restaurant-orders' ); ?>
+        </label>
+        <?php
+    }
+
+    public static function render_settings_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Restaurant Orders Settings', 'restaurant-orders' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( self::OPTION_GROUP );
+                do_settings_sections( 'restaurant-orders' );
+                submit_button();
+                ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Restaurant Orders Tests">
+            <directory suffix=".php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,43 @@
+=== Restaurant Orders ===
+Contributors: example
+Tags: restaurant, orders, rest-api
+Requires at least: 6.0
+Tested up to: 6.5
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+== Description ==
+Provides REST endpoints for managing restaurant menu items and orders, along with optional debug logging of order events.
+
+== Installation ==
+1. Upload the plugin files to the `/wp-content/plugins/restaurant-orders` directory or clone the repository into your plugins folder.
+2. Activate the plugin through the "Plugins" screen in WordPress.
+3. (Optional) Run `bin/install-wp-tests.sh <db-name> <db-user> <db-pass> <db-host>` to provision the WordPress test suite, then execute `phpunit`.
+4. Visit **Settings → Restaurant Orders** to toggle debug logging for order events.
+
+== Roles and Capabilities ==
+* All REST endpoints require authentication.
+* CRUD operations for items and orders require a user with the `manage_options` capability (Administrators by default).
+* Reading item or order data requires the `read` capability.
+
+== REST API Endpoints ==
+All routes live under the `restaurant/v1` namespace.
+
+=== Items ===
+* `POST /restaurant/v1/items` — Create an item. Body: `name` (string), `price` (number), `restaurant_id` (int).
+* `GET /restaurant/v1/items?restaurant_id=<id>` — List items, optionally filtered by `restaurant_id`.
+* `GET /restaurant/v1/items/<id>` — Retrieve a single item.
+* `PUT /restaurant/v1/items/<id>` — Update `name`, `price`, or `restaurant_id`.
+* `DELETE /restaurant/v1/items/<id>` — Delete an item.
+
+=== Orders ===
+* `POST /restaurant/v1/orders` — Create an order. Body: `name` (string, optional), `status` (string, optional), `items` (array), `restaurant_id` (int).
+* `GET /restaurant/v1/orders?restaurant_id=<id>` — List orders, optionally filtered by `restaurant_id`.
+* `GET /restaurant/v1/orders/<id>` — Retrieve a single order.
+* `PUT /restaurant/v1/orders/<id>` — Update `status`, `name`, `items`, or `restaurant_id`.
+* `DELETE /restaurant/v1/orders/<id>` — Delete an order.
+* `POST /restaurant/v1/orders/<id>/notify` — Record notification result (`result` must be `success` or `failure`).
+
+== Debug Logging ==
+Enable the **Debug log** checkbox in the settings page to start writing order lifecycle events (creation, status changes, notification success/failure) to `wp-content/uploads/restaurant-orders-debug.log`.

--- a/restaurant-orders.php
+++ b/restaurant-orders.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Plugin Name: Restaurant Orders
+ * Description: Provides RESTful CRUD for restaurant menu items and orders with debug logging.
+ * Version: 1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/includes/class-restaurant-orders-logger.php';
+require_once __DIR__ . '/includes/class-restaurant-orders-rest.php';
+require_once __DIR__ . '/includes/class-restaurant-orders-settings.php';
+
+class Restaurant_Orders {
+    const ITEM_CPT  = 'restaurant_item';
+    const ORDER_CPT = 'restaurant_order';
+
+    /** @var Restaurant_Orders_Logger */
+    public $logger;
+
+    /** @var Restaurant_Orders_REST */
+    public $rest_controller;
+
+    public function __construct() {
+        $this->logger          = new Restaurant_Orders_Logger();
+        $this->rest_controller = new Restaurant_Orders_REST( $this, $this->logger );
+
+        add_action( 'init', [ $this, 'register_post_types' ] );
+        add_action( 'rest_api_init', [ $this->rest_controller, 'register_routes' ] );
+
+        add_action( 'transition_post_status', [ $this, 'handle_order_status_change' ], 10, 3 );
+
+        add_action( 'plugins_loaded', [ 'Restaurant_Orders_Settings', 'init' ] );
+    }
+
+    public function register_post_types() {
+        register_post_type(
+            self::ITEM_CPT,
+            [
+                'label'        => __( 'Restaurant Item', 'restaurant-orders' ),
+                'public'       => false,
+                'show_ui'      => true,
+                'show_in_menu' => true,
+                'supports'     => [ 'title', 'custom-fields' ],
+            ]
+        );
+
+        register_post_type(
+            self::ORDER_CPT,
+            [
+                'label'        => __( 'Restaurant Order', 'restaurant-orders' ),
+                'public'       => false,
+                'show_ui'      => true,
+                'show_in_menu' => true,
+                'supports'     => [ 'title', 'custom-fields' ],
+            ]
+        );
+    }
+
+    public function handle_order_status_change( $new_status, $old_status, $post ) {
+        if ( self::ORDER_CPT !== $post->post_type || $new_status === $old_status ) {
+            return;
+        }
+
+        $this->logger->log( sprintf( 'Order %d status changed: %s → %s', $post->ID, $old_status, $new_status ) );
+    }
+}
+
+function restaurant_orders() {
+    static $instance;
+    if ( ! isset( $instance ) ) {
+        $instance = new Restaurant_Orders();
+    }
+
+    return $instance;
+}
+
+restaurant_orders();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+    $_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+    require dirname( __DIR__ ) . '/restaurant-orders.php';
+}
+
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-items-and-orders.php
+++ b/tests/test-items-and-orders.php
@@ -1,0 +1,71 @@
+<?php
+class Restaurant_Orders_Items_And_Orders_Test extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+    }
+
+    public function test_item_crud_and_filtering() {
+        $request = new WP_REST_Request( 'POST', '/restaurant/v1/items' );
+        $request->set_param( 'name', 'Burger' );
+        $request->set_param( 'price', 12.5 );
+        $request->set_param( 'restaurant_id', 10 );
+
+        $response = rest_get_server()->dispatch( $request );
+        $item     = $response->get_data();
+
+        $this->assertSame( 'Burger', $item['name'] );
+        $this->assertSame( 10, $item['restaurant_id'] );
+
+        $update = new WP_REST_Request( 'PUT', '/restaurant/v1/items/' . $item['id'] );
+        $update->set_param( 'name', 'Cheese Burger' );
+        $update->set_param( 'price', 14.0 );
+        $update->set_param( 'restaurant_id', 15 );
+
+        $updated = rest_get_server()->dispatch( $update )->get_data();
+        $this->assertSame( 'Cheese Burger', $updated['name'] );
+        $this->assertSame( 14.0, $updated['price'] );
+        $this->assertSame( 15, $updated['restaurant_id'] );
+
+        $filter = new WP_REST_Request( 'GET', '/restaurant/v1/items' );
+        $filter->set_param( 'restaurant_id', 15 );
+        $filtered = rest_get_server()->dispatch( $filter )->get_data();
+
+        $this->assertCount( 1, $filtered );
+        $this->assertSame( $updated['id'], $filtered[0]['id'] );
+
+        $delete = new WP_REST_Request( 'DELETE', '/restaurant/v1/items/' . $item['id'] );
+        $deleted = rest_get_server()->dispatch( $delete )->get_data();
+        $this->assertTrue( $deleted['deleted'] );
+    }
+
+    public function test_order_crud_and_filtering() {
+        $request = new WP_REST_Request( 'POST', '/restaurant/v1/orders' );
+        $request->set_param( 'name', 'Order A' );
+        $request->set_param( 'status', 'pending' );
+        $request->set_param( 'items', [ 1, 2 ] );
+        $request->set_param( 'restaurant_id', 55 );
+
+        $response = rest_get_server()->dispatch( $request );
+        $order    = $response->get_data();
+
+        $this->assertSame( 'pending', $order['status'] );
+
+        $update = new WP_REST_Request( 'PUT', '/restaurant/v1/orders/' . $order['id'] );
+        $update->set_param( 'status', 'completed' );
+
+        $updated = rest_get_server()->dispatch( $update )->get_data();
+        $this->assertSame( 'completed', $updated['status'] );
+
+        $filter = new WP_REST_Request( 'GET', '/restaurant/v1/orders' );
+        $filter->set_param( 'restaurant_id', 55 );
+        $filtered = rest_get_server()->dispatch( $filter )->get_data();
+
+        $this->assertCount( 1, $filtered );
+        $this->assertSame( $order['id'], $filtered[0]['id'] );
+
+        $delete = new WP_REST_Request( 'DELETE', '/restaurant/v1/orders/' . $order['id'] );
+        $deleted = rest_get_server()->dispatch( $delete )->get_data();
+        $this->assertTrue( $deleted['deleted'] );
+    }
+}

--- a/tests/test-order-logging.php
+++ b/tests/test-order-logging.php
@@ -1,0 +1,37 @@
+<?php
+class Restaurant_Orders_Logging_Test extends WP_UnitTestCase {
+    private $log_path;
+
+    public function setUp(): void {
+        parent::setUp();
+        wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+        update_option( Restaurant_Orders_Logger::OPTION_KEY, true );
+
+        $upload_dir     = wp_upload_dir();
+        $this->log_path = trailingslashit( $upload_dir['basedir'] ) . 'restaurant-orders-debug.log';
+        if ( file_exists( $this->log_path ) ) {
+            unlink( $this->log_path );
+        }
+    }
+
+    public function test_logging_flow() {
+        $create = new WP_REST_Request( 'POST', '/restaurant/v1/orders' );
+        $create->set_param( 'restaurant_id', 99 );
+        $create->set_param( 'items', [ 'pizza' ] );
+        $order = rest_get_server()->dispatch( $create )->get_data();
+
+        $update = new WP_REST_Request( 'PUT', '/restaurant/v1/orders/' . $order['id'] );
+        $update->set_param( 'status', 'completed' );
+        rest_get_server()->dispatch( $update );
+
+        $notify = new WP_REST_Request( 'POST', '/restaurant/v1/orders/' . $order['id'] . '/notify' );
+        $notify->set_param( 'result', 'failure' );
+        rest_get_server()->dispatch( $notify );
+
+        $this->assertFileExists( $this->log_path );
+        $contents = file_get_contents( $this->log_path );
+        $this->assertStringContainsString( 'Order ' . $order['id'] . ' created', $contents );
+        $this->assertStringContainsString( 'status changed', $contents );
+        $this->assertStringContainsString( 'Notification failed', $contents );
+    }
+}


### PR DESCRIPTION
## Summary
- add Restaurant Orders plugin with REST endpoints for items and orders plus logging and settings
- include WordPress test suite bootstrap and unit tests for CRUD, filtering, and order logging flows
- document installation steps, permissions, and REST endpoints in readme.txt

## Testing
- Not run (WordPress test suite not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9b3a3bd08326ad30f015a71be466)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a WordPress plugin exposing REST CRUD for items and orders with optional debug logging, an admin setting to toggle it, comprehensive tests, and documentation.
> 
> - **Plugin backend**:
>   - Registers CPTs `restaurant_item` and `restaurant_order` in `restaurant-orders.php`.
>   - Adds REST API (`restaurant/v1`) in `includes/class-restaurant-orders-rest.php`:
>     - Items: create, read, update, delete, list/filter by `restaurant_id`.
>     - Orders: create, read, update, delete, list/filter; `notify` endpoint.
>   - Implements debug logging via `Restaurant_Orders_Logger` writing to `uploads/restaurant-orders-debug.log` and logs order lifecycle events (creation, status changes, notifications).
>   - Introduces admin settings page in `Restaurant_Orders_Settings` to toggle logging.
> - **Testing & tooling**:
>   - Adds PHPUnit config `phpunit.xml.dist` and test bootstrap `tests/bootstrap.php`.
>   - Provides WP test installer script `bin/install-wp-tests.sh`.
>   - Adds unit tests for item/order CRUD, filtering, and logging (`tests/test-*.php`).
> - **Docs**:
>   - Adds `readme.txt` with installation steps, roles/capabilities, and REST endpoint reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d4288a6c353f337a6f6d3b20304df1b0e122ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->